### PR TITLE
Fix docker command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You need to have [Docker](https://www.docker.com/) on your machine to work with 
 
 Then, you are able to build docker files with these commands:
 
-    $ docker build 
+    $ docker build .
     $ docker-compose up -d --build
 
 If everything's fine, then you're ready to make migrations:


### PR DESCRIPTION
The docker command misses a dot.

```sh
~/Django-Movie-Database:main ✓ ➭ docker build
"docker build" requires exactly 1 argument.
See 'docker build --help'.

Usage:  docker build [OPTIONS] PATH | URL | -

Build an image from a Dockerfile
```